### PR TITLE
Extend component to include "removable" boolean prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "3.1.0",
       "dependencies": {
         "@inubekit/foundations": "^2.11.0",
+        "@inubekit/icon": "^1.5.1",
+        "@inubekit/stack": "^2.1.1",
         "@inubekit/text": "^2.2.0"
       },
       "devDependencies": {
@@ -42,6 +44,7 @@
       "peerDependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.0.1",
         "styled-components": "^6.1.8"
       }
     },
@@ -3295,6 +3298,33 @@
       "peerDependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@inubekit/icon": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@inubekit/icon/-/icon-1.5.1.tgz",
+      "integrity": "sha512-KbMTTpLCVbvYhdMC2ZzXlLlW0h0GD1c3fV4LW0Onx2nNe9L9o+aJsjV61XqcrbftBgdK5XxZox96n+PJqEV6SA==",
+      "dependencies": {
+        "@inubekit/foundations": "^2.6.1"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-icons": "^5.0.1",
+        "styled-components": "^6.1.8"
+      }
+    },
+    "node_modules/@inubekit/stack": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@inubekit/stack/-/stack-2.1.1.tgz",
+      "integrity": "sha512-dW0BSOpdkfJHGxg6717iDxWzMYSiC7bQB9jJ3lmDcjdGEryag6NtaPPDcwf+T7gOGfvpO+7rTY/Z02L5oCRSog==",
+      "dependencies": {
+        "@inubekit/foundations": "^2.5.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "styled-components": "^6.1.8"
       }
     },
     "node_modules/@inubekit/text": {
@@ -13511,6 +13541,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
+    },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "peer": true,
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -41,11 +41,14 @@
   },
   "dependencies": {
     "@inubekit/foundations": "^2.11.0",
-    "@inubekit/text": "^2.2.0"
+    "@inubekit/text": "^2.2.0",
+    "@inubekit/icon": "^1.5.1",
+    "@inubekit/stack": "^2.1.1"
   },
   "peerDependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.0.1",
     "styled-components": "^6.1.8"
   },
   "devDependencies": {

--- a/src/Tag/Tag.stories.tsx
+++ b/src/Tag/Tag.stories.tsx
@@ -14,6 +14,7 @@ Default.args = {
   appearance: "primary",
   label: "Tag",
   weight: "normal",
+  removable: false,
 };
 
 export default story;

--- a/src/Tag/index.tsx
+++ b/src/Tag/index.tsx
@@ -4,31 +4,64 @@ import { ITextAppearance, Text } from "@inubekit/text";
 import { inube } from "@inubekit/foundations";
 import { useContext } from "react";
 import { ThemeContext } from "styled-components";
+import { Icon } from "@inubekit/icon";
+import { MdClear } from "react-icons/md";
+import { Stack } from "@inubekit/stack";
 
 interface ITag {
   appearance: ITagAppearance;
   weight?: ITagWeight;
   label: string;
+  removable?: boolean;
+  onClose?: (e: React.MouseEvent<Element, MouseEvent>) => void;
 }
 
 const Tag = (props: ITag) => {
-  const { appearance, weight = "normal", label } = props;
+  const {
+    appearance,
+    weight = "normal",
+    label,
+    removable = false,
+    onClose,
+  } = props;
   const theme: typeof inube = useContext(ThemeContext);
   const textAppearance = (appearance: ITextAppearance, weight: ITagWeight) => {
     return (theme?.tag?.[appearance][weight]?.content?.appearance ||
       inube.tag[appearance][weight].content.appearance) as ITextAppearance;
   };
 
+  const interceptonClose = (e: React.MouseEvent<Element, MouseEvent>) => {
+    try {
+      onClose && onClose(e);
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(error.message);
+      } else {
+        throw new Error("An unknown error occurred");
+      }
+    }
+  };
+
   return (
-    <StyledTag $appearance={appearance} $weight={weight}>
-      <Text
-        type="label"
-        appearance={textAppearance(appearance, weight)}
-        size="small"
-        textAlign="start"
-      >
-        {label}
-      </Text>
+    <StyledTag $appearance={appearance} $weight={weight} $removable={removable}>
+      <Stack alignItems="center" gap="2px">
+        <Text
+          type="label"
+          appearance={textAppearance(appearance, weight)}
+          size="small"
+          textAlign="start"
+        >
+          {label}
+        </Text>
+        {removable && (
+          <Icon
+            onClick={interceptonClose}
+            appearance={textAppearance(appearance, weight)}
+            icon={<MdClear />}
+            size="11px"
+          ></Icon>
+        )}
+      </Stack>
     </StyledTag>
   );
 };

--- a/src/Tag/styles.js
+++ b/src/Tag/styles.js
@@ -4,7 +4,7 @@ import { inube } from "@inubekit/foundations";
 const StyledTag = styled.div`
   display: inline-block;
   border-radius: 4px;
-  padding: 0 4px;
+  padding: ${({ $removable }) => ($removable ? "0 0 0 5px" : "0 4px")};
   background-color: ${({ $weight, $appearance }) =>
     inube.tag[$appearance][$weight].background.color};
 `;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,10 +15,13 @@ export default defineConfig({
       external: [
         "react",
         "react-dom",
+        "react-icons/md",
         "styled-components",
         "react/jsx-runtime",
         "@inubekit/foundations",
         "@inubekit/text",
+        "@inubekit/icon",
+        "@inubekit/stack",
       ],
       output: {
         globals: {


### PR DESCRIPTION
This pull request introduces a significant enhancement to a specific UI component within our application by extending its properties to include a new removable boolean prop. Aimed at providing developers and users with more flexibility in UI customization, this update enables dynamic control over the component's removability feature. The inclusion of the removable prop allows for a more interactive and user-friendly interface, catering to various use cases where the component's presence needs to be optional.