### PR TITLE
Add `id` Prop to Enable Component Management

### DIFF
--- a/src/Tag/index.tsx
+++ b/src/Tag/index.tsx
@@ -10,6 +10,7 @@ import { Stack } from "@inubekit/stack";
 
 interface ITag {
   appearance: ITagAppearance;
+  id?: string;
   weight?: ITagWeight;
   label: string;
   removable?: boolean;

--- a/src/Tag/props.ts
+++ b/src/Tag/props.ts
@@ -22,18 +22,39 @@ const parameters = {
 };
 
 const props = {
-  label: {
-    description: "Controls the text that the tag will display",
-  },
   appearance: {
     control: "select",
     options: appearances,
-    description: "Controls the background color of the tag",
+    description:
+      "Controls the background color of the tag. The available options are predefined styles such as primary, success, danger, etc. Defaults to 'primary'.",
+    type: { name: "enum", value: appearances },
+  },
+  id: {
+    description:
+      "A unique identifier for the tag component. This is an optional field.",
+    type: { name: "string" },
+  },
+  label: {
+    description:
+      "Controls the text that the tag will display. This is a required field.",
+    type: { name: "string" },
+  },
+  onClose: {
+    description:
+      "Callback function that is triggered when the close icon is clicked. This function receives a MouseEvent as an argument.",
+    type: { name: "function", params: [{ name: "MouseEvent" }] },
+  },
+  removable: {
+    description:
+      "Determines if the tag can be removed. When true, a close icon is displayed. Defaults to false.",
+    type: { name: "boolean" },
   },
   weight: {
     control: "select",
     options: weights,
-    description: "Controls the color load that the label receives",
+    description:
+      "Controls the color intensity of the label text. The available options are 'normal' and 'strong'. Defaults to 'normal'.",
+    type: { name: "enum", value: weights },
   },
 };
 


### PR DESCRIPTION
This pull request introduces an `id` prop to the component, providing developers with a straightforward way to manage and reference the component within the DOM. This enhancement is particularly useful for testing, accessibility, and when interacting with the component programmatically.