### PR TITLE
Move tag tokens from foundations to component

### DIFF
--- a/src/Tag/Tokens/tokens.ts
+++ b/src/Tag/Tokens/tokens.ts
@@ -1,0 +1,150 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  primary: {
+    normal: {
+      background: {
+        color: inube.palette.blue.B50,
+      },
+      content: {
+        appearance: "primary",
+      },
+    },
+    strong: {
+      background: {
+        color: inube.palette.blue.B400,
+      },
+      content: {
+        appearance: "light",
+      },
+    },
+  },
+  success: {
+    normal: {
+      background: {
+        color: inube.palette.green.G50,
+      },
+      content: {
+        appearance: "success",
+      },
+    },
+    strong: {
+      background: {
+        color: inube.palette.green.G400,
+      },
+      content: {
+        appearance: "light",
+      },
+    },
+  },
+  warning: {
+    normal: {
+      background: {
+        color: inube.palette.yellow.Y50,
+      },
+      content: {
+        appearance: "warning",
+      },
+    },
+    strong: {
+      background: {
+        color: inube.palette.yellow.Y400,
+      },
+      content: {
+        appearance: "dark",
+      },
+    },
+  },
+  danger: {
+    normal: {
+      background: {
+        color: inube.palette.red.R50,
+      },
+      content: {
+        appearance: "danger",
+      },
+    },
+    strong: {
+      background: {
+        color: inube.palette.red.R400,
+      },
+      content: {
+        appearance: "light",
+      },
+    },
+  },
+  help: {
+    normal: {
+      background: {
+        color: inube.palette.purple.P50,
+      },
+      content: {
+        appearance: "help",
+      },
+    },
+    strong: {
+      background: {
+        color: inube.palette.purple.P400,
+      },
+      content: {
+        appearance: "light",
+      },
+    },
+  },
+  dark: {
+    normal: {
+      background: {
+        color: inube.palette.neutral.N30,
+      },
+      content: {
+        appearance: "dark",
+      },
+    },
+    strong: {
+      background: {
+        color: inube.palette.neutral.N900,
+      },
+      content: {
+        appearance: "light",
+      },
+    },
+  },
+  gray: {
+    normal: {
+      background: {
+        color: inube.palette.neutral.N10,
+      },
+      content: {
+        appearance: "gray",
+      },
+    },
+    strong: {
+      background: {
+        color: inube.palette.neutral.N30,
+      },
+      content: {
+        appearance: "gray",
+      },
+    },
+  },
+  light: {
+    normal: {
+      background: {
+        color: inube.palette.neutral.N0,
+      },
+      content: {
+        appearance: "dark",
+      },
+    },
+    strong: {
+      background: {
+        color: inube.palette.neutral.N10,
+      },
+      content: {
+        appearance: "dark",
+      },
+    },
+  },
+};
+
+export { tokens };

--- a/src/Tag/index.tsx
+++ b/src/Tag/index.tsx
@@ -1,12 +1,12 @@
 import { StyledTag } from "./styles";
 import { ITagAppearance, ITagWeight } from "./props";
 import { ITextAppearance, Text } from "@inubekit/text";
-import { inube } from "@inubekit/foundations";
 import { useContext } from "react";
 import { ThemeContext } from "styled-components";
 import { Icon } from "@inubekit/icon";
 import { MdClear } from "react-icons/md";
 import { Stack } from "@inubekit/stack";
+import { tokens } from "./Tokens/tokens";
 
 interface ITag {
   appearance: ITagAppearance;
@@ -25,10 +25,10 @@ const Tag = (props: ITag) => {
     removable = false,
     onClose,
   } = props;
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { tag: typeof tokens };
   const textAppearance = (appearance: ITextAppearance, weight: ITagWeight) => {
     return (theme?.tag?.[appearance][weight]?.content?.appearance ||
-      inube.tag[appearance][weight].content.appearance) as ITextAppearance;
+      tokens[appearance][weight].content.appearance) as ITextAppearance;
   };
 
   const interceptonClose = (e: React.MouseEvent<Element, MouseEvent>) => {
@@ -61,7 +61,7 @@ const Tag = (props: ITag) => {
             appearance={textAppearance(appearance, weight)}
             icon={<MdClear />}
             size="11px"
-          ></Icon>
+          />
         )}
       </Stack>
     </StyledTag>

--- a/src/Tag/styles.js
+++ b/src/Tag/styles.js
@@ -1,12 +1,12 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 const StyledTag = styled.div`
   display: inline-block;
   border-radius: 4px;
   padding: ${({ $removable }) => ($removable ? "0 0 0 5px" : "0 4px")};
   background-color: ${({ $weight, $appearance }) =>
-    inube.tag[$appearance][$weight].background.color};
+    tokens[$appearance][$weight].background.color};
 `;
 
 export { StyledTag };


### PR DESCRIPTION
This PR relocates the tag tokens from the foundations folder to the component folder, updating all relevant imports to reflect the new structure and ensuring components reference the correct token paths. This update improves the organization, maintainability, and clarity of the codebase.